### PR TITLE
DSE-28614: Update CML AMP AutoML with TPOT to latest Runtime version

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -9,7 +9,6 @@ runtimes:
   - editor: JupyterLab
     kernel: Python 3.9
     edition: Standard
-    version: 2021.12
 
 tasks:
   - type: create_job


### PR DESCRIPTION
This PR removes version field form .project-metadata.yaml so that AMP could use latest Runtime verison.